### PR TITLE
Update spesifikasjon-felter.adoc

### DIFF
--- a/begrep-tbx-ap-no/spesifikasjon-felter.adoc
+++ b/begrep-tbx-ap-no/spesifikasjon-felter.adoc
@@ -2,7 +2,7 @@
 == Felt i standarden
 
 === Begrep
-[properties]
+[horizontal]
 PID til definisjon:: ‘concept’, http://www.w3.org/2004/02/skos/core#Concept
 TBX-representasjon:: <conceptEntry>
 Datatype (med ev. PID til definisjon):: Se attributtene under Begrep.


### PR DESCRIPTION
Redaksjonell endring i asciidoc-koding: forsøker med [horizontal] istedenfor [properties] (kun på den aller første, Begrep)